### PR TITLE
exclude DarwinARM64 from backend builds

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	// mage:import
 	build "github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/magefile/mage/mg"
 )
 
 // Hello prints a message (shows that you can define custom Mage targets).
@@ -13,5 +14,10 @@ func Hello() {
 	fmt.Println("hello plugin developer!")
 }
 
+func BuildAllExceptDarwinARM64() { //revive:disable-line
+	b := build.Build{}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.LinuxARM64, b.LinuxARM)
+}
+
 // Default configures the default target.
-var Default = build.BuildAll
+var Default = BuildAllExceptDarwinARM64


### PR DESCRIPTION
due to error in `release` github action:
```
/usr/bin/tar xz --warning=no-unknown-keyword -C /home/runner/work/_temp/26959392-302a-4b0e-9393-8963dc41f7cd -f /home/runner/work/_temp/38c4cb5a-8a43-41c5-ad75-831b917b6c74
🏃 Running Mage...
/opt/hostedtoolcache/mage-action/1.11.0/x64/mage buildAll
# github.com/grafana/grafana-starter-datasource-backend/pkg
/opt/hostedtoolcache/go/1.15.15/x64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/tmp/go-link-053932266/go.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status

Error: running "go build -o dist/gpx_aws-s3_darwin_arm64 -ldflags -w -s -extldflags "-static" -X 'main.commit=2727bdd4add1e5640c90b39fafa3969aac90b558' -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={"time":1633074603994,"version":"1.0.0","repo":"https://github.com/org-insights/aws-s-3","hash":"2727bdd4add1e5640c90b39fafa3969aac90b558"}' -X 'main.version=1.0.0' ./pkg" failed with exit code 2
Error: The process '/opt/hostedtoolcache/mage-action/1.11.0/x64/mage' failed with exit code 2
```